### PR TITLE
fix: fix default base as per URL spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 .nyc_output
 coverage.lcov
 yarn-error.log
+package-lock.json

--- a/src/url-browser.js
+++ b/src/url-browser.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const defaultBase = self.location ?
-    self.location.protocol + '//' + self.location.host :
-    '';
+const defaultBase = self.location && self.location.protocol + '//' + self.location.host;
 const URL = self.URL;
 
 class URLWithLegacySupport {

--- a/test.js
+++ b/test.js
@@ -9,6 +9,26 @@ const isBrowser =
     typeof document === 'object' &&
     document.nodeType === 9;
 
+test('unspecified base should not throw', (t) => {
+    t.plan(1);
+
+    if (isBrowser) {
+        t.doesNotThrow(() => new URL('http://localhost'));
+    } else {
+        // Hack to force construction of a browser URL in Node to simulate a React Native-like environment where .location does not exist
+        global.self = {
+            URL: global.URL,
+            URLSearchParams: global.URLSearchParams
+        };
+        /* eslint-disable-next-line global-require */
+        const { URLWithLegacySupport: URL } = require('./src/url-browser');
+
+        t.doesNotThrow(() => new URL('http://localhost'));
+
+        delete global.self;
+    }
+});
+
 test('relative', (t) => {
     t.plan(1);
 


### PR DESCRIPTION
The default value set for `base` was causing issues in environments such as React Native where `.location` does not exist. Furthermore, when `base` is unspecified the default value should be `undefined` instead of an empty string.

I'm assuming `package-lock.json` should be ignored considering it was not previously committed. As such, I've added it to the ignore file.

I wasn't really sure how to go about testing this change. AFAIK, it's not possible to remove `location` from `window` as Playwright/Chromium complains if I try delete it. The hack I came up with is construct the browser URL in Node to simulate a React Native-like environment without `location`. Truth to be told, I don't like this approach but this is what we can get away with for the time being to ensure a regression is not introduced.

What do you think @hugomrdias? 

This PR aims to fix https://github.com/ipfs/js-ipfs/issues/3332.