### PR TITLE
fix: ignore location if not available

### DIFF
--- a/src/url-browser.js
+++ b/src/url-browser.js
@@ -8,6 +8,10 @@ function getDefaultBase () {
   if (isReactNative) {
     return 'http://localhost'
   }
+  // in some environments i.e. cloudflare workers location is not available
+  if (!self.location) {
+    return ''
+  }
 
   return self.location.protocol + '//' + self.location.host
 }


### PR DESCRIPTION
Since location object is not available in cloudflare workers, the websocket transport library crashes at runtime without this fix.